### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This app uses a .gtf file of transcripts and the Sentieon STAR tool to generate 
 
 ## What inputs are required for this app to run?
 * `--sentieon_tar`: (file) Tarballed Sentieon package. Currently defaults to use Sentieon 202112.05
-* `--reference_genome_fasta_and_index`:(file) Tarballed GRCh38 reference genome FASTA + index. Current defaults to use GRCh38.no_alt_analysis_set_chr_mask21.fasta-index.tar.gz in 001_Reference
+* `--reference_genome_fasta_and_index`:(file) Tarballed reference genome FASTA + index. Current defaults to use GRCh38.no_alt_analysis_set_chr_mask21.fasta-index.tar.gz in 001_Reference
 * `--annotated_transcripts_gtf`: (file) File providing gene transcript information. Currently defaults to the GENCODE gtf v41 (gencode.v41.annotation.gtf.gz)
 * `--read_length`: (int) The read length of data with which the genome indices will be used. Standard for Illumina instruments is 100; so the default is 100.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This app uses a .gtf file of transcripts and the Sentieon STAR tool to generate 
 * `--sentieon_tar`: (file) Tarballed Sentieon package. Currently defaults to use Sentieon 202112.05
 * `--reference_genome_fasta_and_index`:(file) Tarballed GRCh38 reference genome FASTA + index. Current defaults to use GRCh38.no_alt_analysis_set_chr_mask21.fasta-index.tar.gz in 001_Reference
 * `--annotated_transcripts_gtf`: (file) File providing gene transcript information. Currently defaults to the GENCODE gtf v41 (gencode.v41.annotation.gtf.gz)
-* `--read_length_minus_one`: (int) The read length of data with which the genome indices will be used. Standard for Illumina instruments is 100; so the default for read length minus one is 99.
+* `--read_length`: (int) The read length of data with which the genome indices will be used. Standard for Illumina instruments is 100; so the default for read length minus one is 99.
 
 ## How does this app work?
 eggd_generate_STAR_genome_indices takes an input .gtf file of transcript data, and a reference genome. It uses Sentieon's STAR to create genome indices for use with STAR Fusion.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# eggd_make_genome_indices
+# eggd_generate_STAR_genome_indices
 
 ## What does this app do?
 This app uses a .gtf file of transcripts and the Sentieon STAR tool to generate genome indices, which will annotate a b38 reference genome.
@@ -9,12 +9,9 @@ This app uses a .gtf file of transcripts and the Sentieon STAR tool to generate 
 * `--gtf_file`: (file) File providing gene transcript information. Currently defaults to the GENCODE gtf v41 (gencode.v41.annotation.gtf.gz)
 
 ## How does this app work?
-eggd_make_genome_indices takes an input .gtf file of transcript data, and a reference genome. It creates genome indices.
+eggd_make_genome_indices takes an input .gtf file of transcript data, and a reference genome. It uses Sentieon's STAR to create genome indices for use with STAR Fusion.
 
 ## What does this app output?
 eggd_make_genome_indices outputs a gzipped file of genome indices.
-
-## Notes
-* This app is not ready for production use
 
 ## This app was made by East GLH

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # eggd_make_genome_indices
+
+## What does this app do?
+This app uses a .gtf file of transcripts and the Sentieon STAR tool to generate genome indices, which will annotate a b38 reference genome.
+
+## What inputs are required for this app to run?
+* `--sentieon_tar`: (file) Tarballed Sentieon package. Currently defaults to use Sentieon 202112.05
+* `--reference_genome`:(file) Tarballed GRCh38 reference genome FASTA + index. Current defaults to use GRCh38.no_alt_analysis_set_chr_mask21.fasta-index.tar.gz in 001_Reference
+* `--gtf_file`: (file) File providing gene transcript information. Currently defaults to the GENCODE gtf v41 (gencode.v41.annotation.gtf.gz)
+
+## How does this app work?
+eggd_make_genome_indices takes an input .gtf file of transcript data, and a reference geneome. It creates genome indices.
+
+## What does this app output?
+eggd_make_genome_indices outputs a gzipped file of genome indices.
+
+## Notes
+* This app is not ready for production use
+
+## This app was made by East GLH

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This app uses a .gtf file of transcripts and the Sentieon STAR tool to generate 
 * `--gtf_file`: (file) File providing gene transcript information. Currently defaults to the GENCODE gtf v41 (gencode.v41.annotation.gtf.gz)
 
 ## How does this app work?
-eggd_make_genome_indices takes an input .gtf file of transcript data, and a reference geneome. It creates genome indices.
+eggd_make_genome_indices takes an input .gtf file of transcript data, and a reference genome. It creates genome indices.
 
 ## What does this app output?
 eggd_make_genome_indices outputs a gzipped file of genome indices.

--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@ This app uses a .gtf file of transcripts and the Sentieon STAR tool to generate 
 
 ## What inputs are required for this app to run?
 * `--sentieon_tar`: (file) Tarballed Sentieon package. Currently defaults to use Sentieon 202112.05
-* `--reference_genome`:(file) Tarballed GRCh38 reference genome FASTA + index. Current defaults to use GRCh38.no_alt_analysis_set_chr_mask21.fasta-index.tar.gz in 001_Reference
-* `--gtf_file`: (file) File providing gene transcript information. Currently defaults to the GENCODE gtf v41 (gencode.v41.annotation.gtf.gz)
+* `--reference_genome_fasta_and_index`:(file) Tarballed GRCh38 reference genome FASTA + index. Current defaults to use GRCh38.no_alt_analysis_set_chr_mask21.fasta-index.tar.gz in 001_Reference
+* `--annotated_transcripts_gtf`: (file) File providing gene transcript information. Currently defaults to the GENCODE gtf v41 (gencode.v41.annotation.gtf.gz)
+* `--read_length_minus_one`: (int) The read length of data with which the genome indices will be used. Standard for Illumina instruments is 100; so the default for read length minus one is 99.
 
 ## How does this app work?
-eggd_make_genome_indices takes an input .gtf file of transcript data, and a reference genome. It uses Sentieon's STAR to create genome indices for use with STAR Fusion.
+eggd_generate_STAR_genome_indices takes an input .gtf file of transcript data, and a reference genome. It uses Sentieon's STAR to create genome indices for use with STAR Fusion.
 
 ## What does this app output?
-eggd_make_genome_indices outputs a gzipped file of genome indices.
+eggd_generate_STAR_genome_indices outputs a gzipped file of genome indices. The output file name is in the format `ref_{reference_genome_filename}-gtf_{gtf_filename}-readlength{read_length_number}`
 
 ## This app was made by East GLH

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # eggd_generate_STAR_genome_indices
 
 ## What does this app do?
-This app uses a .gtf file of transcripts and the Sentieon STAR tool to generate genome indices, which will annotate a b38 reference genome.
+This app uses a .gtf file of transcripts and the Sentieon STAR tool to generate genome indices, which will annotate a reference genome.
 
 ## What inputs are required for this app to run?
 * `--sentieon_tar`: (file) Tarballed Sentieon package. Currently defaults to use Sentieon 202112.05
 * `--reference_genome_fasta_and_index`:(file) Tarballed GRCh38 reference genome FASTA + index. Current defaults to use GRCh38.no_alt_analysis_set_chr_mask21.fasta-index.tar.gz in 001_Reference
 * `--annotated_transcripts_gtf`: (file) File providing gene transcript information. Currently defaults to the GENCODE gtf v41 (gencode.v41.annotation.gtf.gz)
-* `--read_length`: (int) The read length of data with which the genome indices will be used. Standard for Illumina instruments is 100; so the default for read length minus one is 99.
+* `--read_length`: (int) The read length of data with which the genome indices will be used. Standard for Illumina instruments is 100; so the default is 100.
 
 ## How does this app work?
 eggd_generate_STAR_genome_indices takes an input .gtf file of transcript data, and a reference genome. It uses Sentieon's STAR to create genome indices for use with STAR Fusion.

--- a/dxapp.json
+++ b/dxapp.json
@@ -41,7 +41,7 @@
         "help": "Read length of data with which the genome indices will be used. Standard for Illumina instruments is 100; so the default is 100",
         "class": "int",
         "patterns": ["*"],
-        "default": 99, 
+        "default": 100, 
         "optional": false
         }
     ],

--- a/dxapp.json
+++ b/dxapp.json
@@ -36,13 +36,13 @@
         "optional": false
         },
         {
-          "name": "read_length_minus_one",
-          "label": "read_length_minus_one",
-          "help": "Read length of data with which the genome indices will be used. Standard for Illumina instruments is 100; so the default for read length minus one is 99",
-          "class": "int",
-          "patterns": ["*"],
-          "default": 99, 
-          "optional": false
+        "name": "read_length_minus_one",
+        "label": "read_length_minus_one",
+        "help": "Read length of data with which the genome indices will be used. Standard for Illumina instruments is 100; so the default for read length minus one is 99",
+        "class": "int",
+        "patterns": ["*"],
+        "default": 99, 
+        "optional": false
         }
     ],
     "outputSpec": [

--- a/dxapp.json
+++ b/dxapp.json
@@ -22,7 +22,7 @@
         "label": "reference_genome_fasta_and_index",
         "help": "Tarballed GRCh38 reference genome FASTA + index",
         "class": "file",
-        "patterns": ["*.tar.gz"],
+        "patterns": ["*.fasta-index.tar.gz"],
         "default": {"$dnanexus_link": "file-Fy4j2G04qB6zQK885B5Q8Pqp"}, 
         "optional": false
         },

--- a/dxapp.json
+++ b/dxapp.json
@@ -27,8 +27,8 @@
         "optional": false
         },
         {
-        "name": "gtf_file",
-        "label": "gtf_file",
+        "name": "annotated_transcripts_gtf",
+        "label": "annotated_transcripts_gtf",
         "help": "Gzipped gene annotation on reference chromosomes and scaffolds in GTF format",
         "class": "file",
         "patterns": ["*.gz"],
@@ -39,7 +39,7 @@
           "name": "read_length_minus_one",
           "label": "read_length_minus_one",
           "help": "Read length of data with which the genome indices will be used. Standard for Illumina instruments is 100; so the default for read length minus one is 99",
-          "class": "file",
+          "class": "int",
           "patterns": ["*"],
           "default": 99, 
           "optional": false
@@ -47,7 +47,7 @@
     ],
     "outputSpec": [
       {
-        "name": "output_genome_indices",
+        "name": "genome_indices",
         "label": "Output genome indices",
         "class": "file",
         "optional": true,

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,0 +1,83 @@
+{
+    "name": "make_genome_indices",
+    "title": "make_genome_indices",
+    "summary": "Make indices",
+    "dxapi": "1.0.0",
+    "version": "1.0.0",
+    "properties": {
+      "githubRelease": "v1.0.0"
+    },
+    "inputSpec": [
+        {
+        "name": "sentieon_tar",
+        "label": "sentieon_tar",
+        "help": "tarballed sentieon",
+        "class": "file",
+        "patterns": ["sentieon-genomics-*.tar.gz"],
+        "default": {"$dnanexus_link": "file-GFbv1x841V8V2zFP8vKf37QZ"}, 
+        "optional": false
+        },
+        {
+        "name": "reference_genome",
+        "label": "reference_genome",
+        "help": "GRCh38 reference genome FASTA + index",
+        "class": "file",
+        "patterns": ["*"],
+        "default": {"$dnanexus_link": "file-Fy4j2G04qB6zQK885B5Q8Pqp"}, 
+        "optional": false
+        },
+        {
+        "name": "gtf_file",
+        "label": "gtf_file",
+        "help": "GGTF annotated transcripts",
+        "class": "file",
+        "patterns": ["*"],
+        "default": {"$dnanexus_link": "file-GGFQFPj42QQxkykZ73z9GGg5"}, 
+        "optional": false
+        }
+    ],
+    "outputSpec": [
+      {
+        "name": "output_indices",
+        "label": "Output genome indices",
+        "class": "file",
+        "optional": true,
+        "patterns": [
+          "*"
+        ],
+        "help": ""
+      }
+    ],
+    "runSpec": {
+      "distribution": "Ubuntu",
+      "release": "20.04",
+      "version": "0",
+      "interpreter": "bash",
+      "file": "src/script.sh",
+      "timeoutPolicy": {
+        "*": {
+          "hours": 1
+        }
+      }
+    },
+    "developers":[
+      "org-emee_1"
+    ],
+    "authorizedUsers": [
+      "org-emee_1"
+    ],
+    "access": {
+      "project": "CONTRIBUTE",
+      "network": ["*"],
+      "allProjects": "VIEW"
+    },
+    "regionalOptions": {
+      "aws:eu-central-1": {
+        "systemRequirements": {
+          "*": {
+            "instanceType": "mem1_ssd1_x32"
+          }
+        }
+      }
+    }
+  }

--- a/dxapp.json
+++ b/dxapp.json
@@ -29,7 +29,7 @@
         {
         "name": "gtf_file",
         "label": "gtf_file",
-        "help": "GGTF annotated transcripts",
+        "help": "GTF annotated transcripts",
         "class": "file",
         "patterns": ["*"],
         "default": {"$dnanexus_link": "file-GGFQFPj42QQxkykZ73z9GGg5"}, 

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,7 +1,7 @@
 {
-    "name": "make_genome_indices",
-    "title": "make_genome_indices",
-    "summary": "Make indices",
+    "name": "eggd_generate_STAR_genome_indices",
+    "title": "eggd_generate_STAR_genome_indices",
+    "summary": "This app uses Sentieon's STAR to make genome indices from an input GTF file",
     "dxapi": "1.0.0",
     "version": "1.0.0",
     "properties": {
@@ -18,18 +18,18 @@
         "optional": false
         },
         {
-        "name": "reference_genome",
-        "label": "reference_genome",
-        "help": "GRCh38 reference genome FASTA + index",
+        "name": "reference_genome_fasta_and_index",
+        "label": "reference_genome_fasta_and_index",
+        "help": "Tarballed GRCh38 reference genome FASTA + index",
         "class": "file",
-        "patterns": ["*"],
+        "patterns": ["*.tar.gz"],
         "default": {"$dnanexus_link": "file-Fy4j2G04qB6zQK885B5Q8Pqp"}, 
         "optional": false
         },
         {
         "name": "gtf_file",
         "label": "gtf_file",
-        "help": "Gzipped GTF annotated transcripts",
+        "help": "Gzipped gene annotation on reference chromosomes and scaffolds in GTF format",
         "class": "file",
         "patterns": ["*.gz"],
         "default": {"$dnanexus_link": "file-GGfq5Kj42QQkjj6f4kjG418x"}, 
@@ -38,7 +38,7 @@
     ],
     "outputSpec": [
       {
-        "name": "output_indices",
+        "name": "output_genome_indices",
         "label": "Output genome indices",
         "class": "file",
         "optional": true,
@@ -56,7 +56,7 @@
       "file": "src/script.sh",
       "timeoutPolicy": {
         "*": {
-          "hours": 1
+          "hours": 3
         }
       }
     },

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,7 +1,7 @@
 {
     "name": "eggd_generate_STAR_genome_indices",
     "title": "eggd_generate_STAR_genome_indices",
-    "summary": "This app uses Sentieon's STAR to make genome indices from an input GTF file",
+    "summary": "This app uses Sentieon's STAR to make genome indices from an input GTF file and reference genome",
     "dxapi": "1.0.0",
     "version": "1.0.0",
     "properties": {

--- a/dxapp.json
+++ b/dxapp.json
@@ -31,14 +31,14 @@
         "label": "annotated_transcripts_gtf",
         "help": "Gzipped gene annotation on reference chromosomes and scaffolds in GTF format. This must be the same genome build as the reference genome.",
         "class": "file",
-        "patterns": ["*.gz"],
+        "patterns": ["*.gtf.gz"],
         "default": {"$dnanexus_link": "file-GGfq5Kj42QQkjj6f4kjG418x"}, 
         "optional": false
         },
         {
-        "name": "read_length_minus_one",
-        "label": "read_length_minus_one",
-        "help": "Read length of data with which the genome indices will be used. Standard for Illumina instruments is 100; so the default for read length minus one is 99",
+        "name": "read_length",
+        "label": "read_length",
+        "help": "Read length of data with which the genome indices will be used. Standard for Illumina instruments is 100; so the default is 100",
         "class": "int",
         "patterns": ["*"],
         "default": 99, 

--- a/dxapp.json
+++ b/dxapp.json
@@ -34,6 +34,15 @@
         "patterns": ["*.gz"],
         "default": {"$dnanexus_link": "file-GGfq5Kj42QQkjj6f4kjG418x"}, 
         "optional": false
+        },
+        {
+          "name": "read_length_minus_one",
+          "label": "read_length_minus_one",
+          "help": "Read length of data with which the genome indices will be used. Standard for Illumina instruments is 100; so the default for read length minus one is 99",
+          "class": "file",
+          "patterns": ["*"],
+          "default": 99, 
+          "optional": false
         }
     ],
     "outputSpec": [

--- a/dxapp.json
+++ b/dxapp.json
@@ -29,10 +29,10 @@
         {
         "name": "gtf_file",
         "label": "gtf_file",
-        "help": "GTF annotated transcripts",
+        "help": "Gzipped GTF annotated transcripts",
         "class": "file",
-        "patterns": ["*"],
-        "default": {"$dnanexus_link": "file-GGFQFPj42QQxkykZ73z9GGg5"}, 
+        "patterns": ["*.gz"],
+        "default": {"$dnanexus_link": "file-GGfq5Kj42QQkjj6f4kjG418x"}, 
         "optional": false
         }
     ],

--- a/dxapp.json
+++ b/dxapp.json
@@ -29,7 +29,7 @@
         {
         "name": "annotated_transcripts_gtf",
         "label": "annotated_transcripts_gtf",
-        "help": "Gzipped gene annotation on reference chromosomes and scaffolds in GTF format",
+        "help": "Gzipped gene annotation on reference chromosomes and scaffolds in GTF format. This must be the same genome build as the reference genome.",
         "class": "file",
         "patterns": ["*.gz"],
         "default": {"$dnanexus_link": "file-GGfq5Kj42QQkjj6f4kjG418x"}, 

--- a/resources/home/dnanexus/README.txt
+++ b/resources/home/dnanexus/README.txt
@@ -1,0 +1,25 @@
+In order to use Sentieon at DNAnexus you will need a license.
+The code enclosed in this folder will help you use the license
+you use to run the official Sentieon DNANexus apps in other
+DNAnexus environments such as applets.
+
+The folder contains 4 files:
+* README.txt: this file.
+* license_setup.sh: the main script that you will need to run in
+  your applet code, which gathers the license info, starts the
+  process that takes care of updating the license info, and sets
+  up all the necessary settings for our tools to run.
+* helper_funcs.sh: a library script that contains the necessary
+  functions to find where the license data is located and download
+  it to the worker at DNAnexus.
+* license_auth.sh: a script that will take care of updating the
+  license info regularly and keep it up to date.
+
+You need to put the all 3 files (except the README.txt file) in
+the home folder of your applet (/home/dnanexus) and call the
+license_setup.sh script at the beginning of the applet run.
+In addition, you need to make sure that the applet has external network
+access, and VIEW access to your projects (to be able to find the license
+information), so you will need to add the following access rules to your
+dxjson.app:
+ "access": { "network": ["*"], "allProjects": "VIEW" }

--- a/resources/home/dnanexus/helper_funcs.sh
+++ b/resources/home/dnanexus/helper_funcs.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+##license related functions, different for applets
+sentieon_install_dir()
+{
+	echo /usr/local/sentieon-genomics-*|awk '{print $1}'
+}
+
+download_license_token()
+{
+	#download the record contained in the $license_project
+	for i in $(seq 1 5); do
+		#use record instead
+		RECORD_NAME=$(dx find data --class record --path $license_project --name Sentieon_License --brief|head -1)
+		dx describe $RECORD_NAME --json | jq .details >~/Sentieon_License && break || sleep 5;
+	done
+	#cat to different file and then move, to prevent unlikely race condition
+	cat ~/Sentieon_License | base64 > ~/Sentieon_License_encrypt_tmp
+	mv ~/Sentieon_License_encrypt_tmp ~/Sentieon_License_encrypt
+}
+
+find_license_project()
+{
+	#need to select the right project incase the user belongs to multiple orgs
+	billTo=$(dx describe $DX_JOB_ID --json |jq .billTo)
+	launchedBy=$(dx describe $DX_JOB_ID --json|jq .launchedBy)
+	#first look for the project shared with the billTo
+	find_license_project_look_only $billTo
+	#if not found look for all projects that the user has access to, and find the one shared with the billTo;
+	#This is necessary to support the use case where the user is part of a collaborator org but not the billTo one
+	if [ "$license_project" == "" ]; then
+		echo "Could not find license folder containing a valid license shared with $billTo, trying to find collaborator license folders" 1>&2
+		for project in $(dx api system findProjects '{"billTo":"user-sentieon_license","tags":"Sentieon_License","level":"VIEW"}'|jq .results[].id|sed 's|"||g'); do
+			if [ "$project" != "null" ]; then
+				for auth_user in $(dx api system findProjectMembers '{"project":"'$project'"}'|jq .results[].id|sed 's|"||g'); do
+					if [ "$auth_user" == "$billTo" ]; then
+						check_license_valid $project
+					fi
+				done
+			fi
+		done
+	fi
+	#if still not found, look for license for user
+	if [ "$license_project" == "" ]; then
+		echo "Could not find license folder containing a valid license shared with $billTo or a collaborator project, trying to find license folder shared with $launchedBy" 1>&2
+		find_license_project_look_only $launchedBy
+	fi 
+	#if found expired license, set it up so that correct error message gets produced
+	if [ "$license_project" == "" ] && [ "$license_project_expired" != "" ]; then
+		echo "Project found but it contains an expired license"
+		license_project=$license_project_expired
+	fi
+}
+
+find_license_project_look_only()
+{
+	#if there are multiple projects, find the one that is still valid, and prioritize non-EVALs
+	for project in $(dx api system findProjects '{"billTo":"user-sentieon_license","tags":"Sentieon_License","level":"VIEW","sharedWith":'$1'}'|jq .results[].id|sed 's|"||g'); do
+		if [ "$project" != "null" ]; then
+			check_license_valid $project
+		fi
+	done
+}
+
+check_license_valid()
+{
+	project=$1
+	RECORD_NAME=$(dx find data --class record --path $project --name Sentieon_License --brief|head -1)
+	RECORD=$(dx describe $RECORD_NAME --json)
+	if [ $(date -d $(echo $RECORD |jq .details.license_expiration|sed 's|"||g') +"%Y%m%d") -ge $(date +"%Y%m%d") ]; then
+		#replace license_project if this is purchased, to give priority to purchased
+		if [ "$license_project" != "" ]; then
+			if [ "$(echo $RECORD |jq .details.key|sed 's|"||g'|cut -c1-5)" != "EVAL0" ]; then
+				license_project=$project
+			fi
+		else
+			license_project=$project
+		fi
+	else
+		license_project_expired=$project
+	fi
+}
+
+error_report()
+{
+	dx-jobutil-report-error "$1"
+	#also echo the error message to stderr, as DNAnexus does not do this
+	echo "$1" 1>&2
+}
+

--- a/resources/home/dnanexus/license_auth.sh
+++ b/resources/home/dnanexus/license_auth.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+license_project=$1
+
+source ~/helper_funcs.sh
+
+#refresh the token file
+while sleep 300; do
+	download_license_token
+done

--- a/resources/home/dnanexus/license_setup.sh
+++ b/resources/home/dnanexus/license_setup.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+source ~/helper_funcs.sh
+SENTIEON_INSTALL_DIR=$(sentieon_install_dir)
+sentieon_procs=$(nproc)
+# Setup license
+# find corresponding project where license token information is and download it
+find_license_project
+if [ "$license_project" == "" ]; then
+	error_report "You do not have a license to use this app. Please contact Sentieon at info@sentieon.com to request a license. The app will exit now."
+fi
+download_license_token
+
+# Kick token refresh script
+bash ~/license_auth.sh $license_project&
+
+# Set license settings
+job_tag=$(cat ~/Sentieon_License|jq '.job_tag')
+license_server_location=$(cat ~/Sentieon_License|jq '.license_server_location'|sed 's|"||g')
+if [ "$license_server_location" == "null" ] || [ "$license_server_location" == "" ]; then
+	#try global location
+	set +e
+	license_server_location=$(curl -s https://sentieon-bundle.s3.amazonaws.com/dnanexus/DNAnexus_app|jq '.license_server_location'|sed 's|"||g')
+	set -e
+	if [ "$license_server_location" == "null" ] || [ "$license_server_location" == "" ]; then
+		license_server_location=master.sentieon.com:9010
+	fi
+fi
+export SENTIEON_LICENSE=$license_server_location
+export SENTIEON_AUTH_MECH=dnanexus_app
+export SENTIEON_AUTH_DATA=~/Sentieon_License_encrypt
+export SENTIEON_JOB_TAG=$job_tag
+
+# Error checking: Check license validity before running anything
+${SENTIEON_INSTALL_DIR}/bin/sentieon licclnt ping -s $SENTIEON_LICENSE 2> >(tee lic_errlog) || error_report "There is an issue with your license. Please contact Sentieon at support@sentieon.com and report your username, org, the billing org you are using to run Sentieon, and the following error message \"$(cat lic_errlog)\". The app will exit now."
+
+#other settings
+export LD_PRELOAD=$SENTIEON_INSTALL_DIR/lib/libjemalloc.so.1
+export MALLOC_CONF=lg_dirty_mult:-1
+

--- a/resources/home/dnanexus/license_setup.sh
+++ b/resources/home/dnanexus/license_setup.sh
@@ -34,7 +34,7 @@ export SENTIEON_JOB_TAG=$job_tag
 # Error checking: Check license validity before running anything
 ${SENTIEON_INSTALL_DIR}/bin/sentieon licclnt ping -s $SENTIEON_LICENSE 2> >(tee lic_errlog) || error_report "There is an issue with your license. Please contact Sentieon at support@sentieon.com and report your username, org, the billing org you are using to run Sentieon, and the following error message \"$(cat lic_errlog)\". The app will exit now."
 
-#other settings
-export LD_PRELOAD=$SENTIEON_INSTALL_DIR/lib/libjemalloc.so.1
-export MALLOC_CONF=lg_dirty_mult:-1
+# Libjemalloc setup
+sudo apt install libjemalloc2
+export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 

--- a/src/script.sh
+++ b/src/script.sh
@@ -45,8 +45,7 @@ CUT_REFERENCE=${REFNAME##*/}
 CUT_REFERENCE=${CUT_REFERENCE%.fasta-index.tar.gz*}
 CUT_GTF=${GTFNAME##*/}
 CUT_GTF=${CUT_GTF%.gtf*}
-let READLENGTH=${read_length_minus_one}+1
-FILENAME=ref_${CUT_REFERENCE}-gtf_${CUT_GTF}-readlength${READLENGTH}
+FILENAME=ref_${CUT_REFERENCE}-gtf_${CUT_GTF}-readlength${read_length}
 
 # Configure output directories with output filename 
 mkdir /home/dnanexus/$FILENAME
@@ -57,6 +56,7 @@ NUMBER_THREADS=${INSTANCE##*_x}
 export REFERENCE=/home/dnanexus/reference_genome_fasta_and_index/*.fa  # Reference genome, standard GRCh38
 GTF=/home/dnanexus/in/annotated_transcripts_gtf/*gtf  # Input .gtf annotation file
 OUTPUT_DIR=/home/dnanexus/$FILENAME
+let READ_LENGTH_MINUS_ONE=${read_length}-1
 
 # Run STAR command to generate genome indices
 sentieon STAR --runThreadN ${NUMBER_THREADS} \
@@ -64,7 +64,7 @@ sentieon STAR --runThreadN ${NUMBER_THREADS} \
     --genomeDir ${OUTPUT_DIR} \
     --genomeFastaFiles ${REFERENCE} \
     --sjdbGTFfile ${GTF} \
-    --sjdbOverhang ${read_length_minus_one}
+    --sjdbOverhang ${READ_LENGTH_MINUS_ONE}
 
 # Tar and gzip output file
 tar -czvf $FILENAME.tar.gz /home/dnanexus/$FILENAME

--- a/src/script.sh
+++ b/src/script.sh
@@ -6,7 +6,6 @@ dx-download-all-inputs # download inputs from json
 
 mkdir /home/dnanexus/genomeDir
 mkdir /home/dnanexus/reference_genome_fasta_and_index
-mkdir /home/dnanexus/gtf
 
 # Unpack tarred input files and decompress gzipped files
 tar xvzf /home/dnanexus/in/sentieon_tar/sentieon-genomics-*.tar.gz -C /usr/local

--- a/src/script.sh
+++ b/src/script.sh
@@ -6,14 +6,12 @@ dx-download-all-inputs # download inputs from json
 
 mkdir /home/dnanexus/genomeDir
 mkdir /home/dnanexus/reference_genome_fasta_and_index
-mkdir /home/dnanexus/output_genome_indices
 mkdir /home/dnanexus/gtf
-mkdir -p /home/dnanexus/out/output_genome_indices/
 
 # Unpack tarred input files and decompress gzipped files
 tar xvzf /home/dnanexus/in/sentieon_tar/sentieon-genomics-*.tar.gz -C /usr/local
 tar xvzf /home/dnanexus/in/reference_genome_fasta_and_index/*tar.gz -C /home/dnanexus/reference_genome_fasta_and_index
-gunzip /home/dnanexus/in/gtf_file/*.gz
+gunzip /home/dnanexus/in/annotated_transcripts_gtf/*.gz
 
 source /home/dnanexus/license_setup.sh # run license setup script
 
@@ -27,12 +25,39 @@ export PATH="$SENTIEON_BIN_DIR:$PATH"
 # This can be extracted from the DNAnexus instance type
 INSTANCE=$(dx describe --json $DX_JOB_ID | jq -r '.instanceType')  # Extract instance type
 
+# Output file name will be formatted as follows: 
+# ref_filename-gtf_filename-readlengthN
+REFPATH=/home/dnanexus/in/reference_genome_fasta_and_index/
+REFNAME=( "$REFPATH"*.fasta-index.tar.gz )
+# If there is no file matching the pattern, REFNAME will = *.fasta-index.tar.gz
+# Therefore can filter incorrect filenames based on the presence of an asterisk
+if [[ "$REFNAME" == *"*"* ]];
+    then { echo "Input reference file name not found; possibly missing .fasta-index.tar.gz suffix" >&2; exit 1; }
+fi
+GTFPATH=/home/dnanexus/in/annotated_transcripts_gtf/
+GTFNAME=( "$GTFPATH"*.gtf )
+# If there is no file matching the pattern, GTFNAME will = *.gtf
+# Therefore can filter incorrect filenames based on the presence of an asterisk
+if [[ "$GTFNAME" == *"*"* ]];
+    then { echo "Input transcripts gtf file name not found; possibly missing .gtf suffix" >&2; exit 1; }
+fi
+CUT_REFERENCE=${REFNAME##*/}
+CUT_REFERENCE=${CUT_REFERENCE%.fasta-index.tar.gz*}
+CUT_GTF=${GTFNAME##*/}
+CUT_GTF=${CUT_GTF%.gtf*}
+let READLENGTH=${read_length_minus_one}+1
+FILENAME=ref_${CUT_REFERENCE}-gtf_${CUT_GTF}-readlength${READLENGTH}
+
+# Configure output directories with output filename 
+mkdir /home/dnanexus/$FILENAME
+mkdir -p /home/dnanexus/out/$FILENAME
+
 ## Generate genome indices
 # Define input variables for STAR command
 NUMBER_THREADS=${INSTANCE##*_x}
 export REFERENCE=/home/dnanexus/reference_genome_fasta_and_index/*.fa  # Reference genome, standard GRCh38
-GTF=/home/dnanexus/in/gtf_file/*gtf  # Input .gtf annotation file
-OUTPUT_DIR=/home/dnanexus/output_genome_indices
+GTF=/home/dnanexus/in/annotated_transcripts_gtf/*gtf  # Input .gtf annotation file
+OUTPUT_DIR=/home/dnanexus/$FILENAME
 
 # Run STAR command to generate genome indices
 sentieon STAR --runThreadN ${NUMBER_THREADS} \
@@ -43,9 +68,10 @@ sentieon STAR --runThreadN ${NUMBER_THREADS} \
     --sjdbOverhang ${read_length_minus_one}
 
 # Tar and gzip output file
-tar -czvf output_genome_indices.tar.gz /home/dnanexus/output_genome_indices
-
+tar -czvf $FILENAME.tar.gz /home/dnanexus/$FILENAME
 # Move to /out/ folder to allow output to be uploaded
-mv output_genome_indices.tar.gz /home/dnanexus/out/output_genome_indices
+mv $FILENAME.tar.gz /home/dnanexus/out/$FILENAME
 
+output_indices=$(dx upload home/dnanexus/out/$FILENAME/$FILENAME.tar.gz --brief)
+dx-jobutil-add-output genome_indices "$output_indices" --class=file
 dx-upload-all-outputs

--- a/src/script.sh
+++ b/src/script.sh
@@ -5,14 +5,14 @@ set -exo pipefail #if any part goes wrong, job will fail
 dx-download-all-inputs # download inputs from json
 
 mkdir /home/dnanexus/genomeDir
-mkdir /home/dnanexus/reference_genome
-mkdir /home/dnanexus/output_indices
+mkdir /home/dnanexus/reference_genome_fasta_and_index
+mkdir /home/dnanexus/output_genome_indices
 mkdir /home/dnanexus/gtf
-mkdir -p /home/dnanexus/out/output_indices/
+mkdir -p /home/dnanexus/out/output_genome_indices/
 
 # Unpack tarred input files and decompress gzipped files
 tar xvzf /home/dnanexus/in/sentieon_tar/sentieon-genomics-*.tar.gz -C /usr/local
-tar xvzf /home/dnanexus/in/reference_genome/*tar.gz -C /home/dnanexus/reference_genome
+tar xvzf /home/dnanexus/in/reference_genome_fasta_and_index/*tar.gz -C /home/dnanexus/reference_genome_fasta_and_index
 gunzip /home/dnanexus/in/gtf_file/*.gz
 
 source /home/dnanexus/license_setup.sh # run license setup script
@@ -30,10 +30,10 @@ INSTANCE=$(dx describe --json $DX_JOB_ID | jq -r '.instanceType')  # Extract ins
 ## Generate genome indices
 # Define input variables for STAR command
 NUMBER_THREADS=${INSTANCE##*_x}
-export REFERENCE=/home/dnanexus/reference_genome/*.fa  # Reference genome, standard GRCh38
+export REFERENCE=/home/dnanexus/reference_genome_fasta_and_index/*.fa  # Reference genome, standard GRCh38
 GTF=/home/dnanexus/in/gtf_file/*gtf  # Input .gtf annotation file
 READ_LENGTH_MINUS_1=99
-OUTPUT_DIR=/home/dnanexus/output_indices
+OUTPUT_DIR=/home/dnanexus/output_genome_indices
 
 # Run STAR command to generate genome indices
 sentieon STAR --runThreadN ${NUMBER_THREADS} \
@@ -44,9 +44,9 @@ sentieon STAR --runThreadN ${NUMBER_THREADS} \
     --sjdbOverhang ${READ_LENGTH_MINUS_1}
 
 # Tar and gzip output file
-tar -czvf output_indices.tar.gz /home/dnanexus/output_indices
+tar -czvf output_genome_indices.tar.gz /home/dnanexus/output_genome_indices
 
 # Move to /out/ folder to allow output to be uploaded
-mv output_indices.tar.gz /home/dnanexus/out/output_indices
+mv output_genome_indices.tar.gz /home/dnanexus/out/output_genome_indices
 
 dx-upload-all-outputs

--- a/src/script.sh
+++ b/src/script.sh
@@ -4,14 +4,14 @@ set -exo pipefail #if any part goes wrong, job will fail
 
 dx-download-all-inputs # download inputs from json
 
-# resources folder will not exist on worker, so removed here.
 mkdir /home/dnanexus/genomeDir
 mkdir /home/dnanexus/reference_genome
 mkdir /home/dnanexus/output_indices
 mkdir /home/dnanexus/gtf
 mkdir -p /home/dnanexus/out/output_indices/
 
-tar xvzf /home/dnanexus/in/sentieon_tar/sentieon-genomics-*.tar.gz -C /usr/local # unpack tar
+# Unpack tarred input files and decompress gzipped files
+tar xvzf /home/dnanexus/in/sentieon_tar/sentieon-genomics-*.tar.gz -C /usr/local
 tar xvzf /home/dnanexus/in/reference_genome/*tar.gz -C /home/dnanexus/reference_genome
 gunzip /home/dnanexus/in/gtf_file/*.gz
 

--- a/src/script.sh
+++ b/src/script.sh
@@ -20,14 +20,15 @@ SENTIEON_BIN_DIR=$(echo $SENTIEON_INSTALL_DIR/bin)
 
 export PATH="$SENTIEON_BIN_DIR:$PATH"
 
+## Generate genome indices
+# Define input variables for STAR command
 NUMBER_THREADS=32
-export REFERENCE=/home/dnanexus/reference_genome/*.fa # Reference genome, standard GRCh38
-echo $REFERENCE
-GTF=/home/dnanexus/in/gtf_file/*gtf
+export REFERENCE=/home/dnanexus/reference_genome/*.fa  # Reference genome, standard GRCh38
+GTF=/home/dnanexus/in/gtf_file/*gtf  # Input .gtf annotation file
 READ_LENGTH_MINUS_1=100
 OUTPUT_DIR=/home/dnanexus/out/output_indices
 
-
+# Run STAR command to generate genome indices
 sentieon STAR --runThreadN ${NUMBER_THREADS} --runMode genomeGenerate --genomeDir ${OUTPUT_DIR} --genomeFastaFiles ${REFERENCE} --sjdbGTFfile ${GTF} --sjdbOverhang ${READ_LENGTH_MINUS_1}
 
 dx-upload-all-outputs

--- a/src/script.sh
+++ b/src/script.sh
@@ -7,6 +7,7 @@ dx-download-all-inputs # download inputs from json
 # resources folder will not exist on worker, so removed here.
 mkdir /home/dnanexus/genomeDir
 mkdir /home/dnanexus/reference_genome
+mkdir /home/dnanexus/output_indices
 mkdir -p /home/dnanexus/out/output_indices/output_indices
 
 tar xvzf /home/dnanexus/in/sentieon_tar/sentieon-genomics-*.tar.gz -C /usr/local # unpack tar
@@ -26,12 +27,20 @@ NUMBER_THREADS=32
 export REFERENCE=/home/dnanexus/reference_genome/*.fa  # Reference genome, standard GRCh38
 GTF=/home/dnanexus/in/gtf_file/*gtf  # Input .gtf annotation file
 READ_LENGTH_MINUS_1=100
-OUTPUT_DIR=/home/dnanexus/out/output_indices/output_indices
+OUTPUT_DIR=/home/dnanexus/output_indices
 
 # Run STAR command to generate genome indices
-sentieon STAR --runThreadN ${NUMBER_THREADS} --runMode genomeGenerate --genomeDir ${OUTPUT_DIR} --genomeFastaFiles ${REFERENCE} --sjdbGTFfile ${GTF} --sjdbOverhang ${READ_LENGTH_MINUS_1}
+sentieon STAR --runThreadN ${NUMBER_THREADS} \
+    --runMode genomeGenerate \
+    --genomeDir ${OUTPUT_DIR} \
+    --genomeFastaFiles ${REFERENCE} \
+    --sjdbGTFfile ${GTF} \
+    --sjdbOverhang ${READ_LENGTH_MINUS_1}
 
 # Tar and gzip output file
-tar -czvf output_indices.tar.gz /home/dnanexus/out/output_indices/output_indices
+tar -czvf output_indices.tar.gz /home/dnanexus/output_indices
+
+# Move to /out/ folder to allow output to be uploaded
+mv output_indices.tar.gz /home/dnanexus/out/output_indices
 
 dx-upload-all-outputs

--- a/src/script.sh
+++ b/src/script.sh
@@ -50,7 +50,6 @@ FILENAME=ref_${CUT_REFERENCE}-gtf_${CUT_GTF}-readlength${READLENGTH}
 
 # Configure output directories with output filename 
 mkdir /home/dnanexus/$FILENAME
-mkdir -p /home/dnanexus/out/$FILENAME
 
 ## Generate genome indices
 # Define input variables for STAR command
@@ -70,8 +69,7 @@ sentieon STAR --runThreadN ${NUMBER_THREADS} \
 # Tar and gzip output file
 tar -czvf $FILENAME.tar.gz /home/dnanexus/$FILENAME
 # Move to /out/ folder to allow output to be uploaded
-mv $FILENAME.tar.gz /home/dnanexus/out/$FILENAME
+#mv $FILENAME.tar.gz /home/dnanexus/out/$FILENAME
 
-output_indices=$(dx upload /home/dnanexus/out/$FILENAME/$FILENAME.tar.gz --brief)
+output_indices=$(dx upload /home/dnanexus/$FILENAME.tar.gz --brief)
 dx-jobutil-add-output genome_indices "$output_indices" --class=file
-dx-upload-all-outputs

--- a/src/script.sh
+++ b/src/script.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -exo pipefail #if any part goes wrong, job will fail
+
+dx-download-all-inputs # download inputs from json
+
+# resources folder will not exist on worker, so removed here.
+mkdir /home/dnanexus/genomeDir
+mkdir /home/dnanexus/reference_genome
+mkdir -p /home/dnanexus/out/output_indices
+
+tar xvzf /home/dnanexus/in/sentieon_tar/sentieon-genomics-*.tar.gz -C /usr/local # unpack tar
+tar xvzf /home/dnanexus/in/reference_genome/*tar.gz -C /home/dnanexus/reference_genome
+
+source /home/dnanexus/license_setup.sh # run license setup script
+
+export SENTIEON_INSTALL_DIR=/usr/local/sentieon-genomics-*
+
+SENTIEON_BIN_DIR=$(echo $SENTIEON_INSTALL_DIR/bin)
+
+export PATH="$SENTIEON_BIN_DIR:$PATH"
+
+NUMBER_THREADS=32
+export REFERENCE=/home/dnanexus/reference_genome/*.fa # Reference genome, standard GRCh38
+echo $REFERENCE
+GTF=/home/dnanexus/in/gtf_file/*gtf
+READ_LENGTH_MINUS_1=100
+OUTPUT_DIR=/home/dnanexus/out/output_indices
+
+
+sentieon STAR --runThreadN ${NUMBER_THREADS} --runMode genomeGenerate --genomeDir ${OUTPUT_DIR} --genomeFastaFiles ${REFERENCE} --sjdbGTFfile ${GTF} --sjdbOverhang ${READ_LENGTH_MINUS_1}
+
+dx-upload-all-outputs

--- a/src/script.sh
+++ b/src/script.sh
@@ -72,6 +72,6 @@ tar -czvf $FILENAME.tar.gz /home/dnanexus/$FILENAME
 # Move to /out/ folder to allow output to be uploaded
 mv $FILENAME.tar.gz /home/dnanexus/out/$FILENAME
 
-output_indices=$(dx upload home/dnanexus/out/$FILENAME/$FILENAME.tar.gz --brief)
+output_indices=$(dx upload /home/dnanexus/out/$FILENAME/$FILENAME.tar.gz --brief)
 dx-jobutil-add-output genome_indices "$output_indices" --class=file
 dx-upload-all-outputs

--- a/src/script.sh
+++ b/src/script.sh
@@ -32,7 +32,6 @@ INSTANCE=$(dx describe --json $DX_JOB_ID | jq -r '.instanceType')  # Extract ins
 NUMBER_THREADS=${INSTANCE##*_x}
 export REFERENCE=/home/dnanexus/reference_genome_fasta_and_index/*.fa  # Reference genome, standard GRCh38
 GTF=/home/dnanexus/in/gtf_file/*gtf  # Input .gtf annotation file
-READ_LENGTH_MINUS_1=99
 OUTPUT_DIR=/home/dnanexus/output_genome_indices
 
 # Run STAR command to generate genome indices
@@ -41,7 +40,7 @@ sentieon STAR --runThreadN ${NUMBER_THREADS} \
     --genomeDir ${OUTPUT_DIR} \
     --genomeFastaFiles ${REFERENCE} \
     --sjdbGTFfile ${GTF} \
-    --sjdbOverhang ${READ_LENGTH_MINUS_1}
+    --sjdbOverhang ${read_length_minus_one}
 
 # Tar and gzip output file
 tar -czvf output_genome_indices.tar.gz /home/dnanexus/output_genome_indices

--- a/src/script.sh
+++ b/src/script.sh
@@ -7,7 +7,7 @@ dx-download-all-inputs # download inputs from json
 # resources folder will not exist on worker, so removed here.
 mkdir /home/dnanexus/genomeDir
 mkdir /home/dnanexus/reference_genome
-mkdir -p /home/dnanexus/out/output_indices
+mkdir -p /home/dnanexus/out/output_indices/output_indices
 
 tar xvzf /home/dnanexus/in/sentieon_tar/sentieon-genomics-*.tar.gz -C /usr/local # unpack tar
 tar xvzf /home/dnanexus/in/reference_genome/*tar.gz -C /home/dnanexus/reference_genome
@@ -26,9 +26,12 @@ NUMBER_THREADS=32
 export REFERENCE=/home/dnanexus/reference_genome/*.fa  # Reference genome, standard GRCh38
 GTF=/home/dnanexus/in/gtf_file/*gtf  # Input .gtf annotation file
 READ_LENGTH_MINUS_1=100
-OUTPUT_DIR=/home/dnanexus/out/output_indices
+OUTPUT_DIR=/home/dnanexus/out/output_indices/output_indices
 
 # Run STAR command to generate genome indices
 sentieon STAR --runThreadN ${NUMBER_THREADS} --runMode genomeGenerate --genomeDir ${OUTPUT_DIR} --genomeFastaFiles ${REFERENCE} --sjdbGTFfile ${GTF} --sjdbOverhang ${READ_LENGTH_MINUS_1}
+
+# Tar and gzip output file
+tar -czvf output_indices.tar.gz /home/dnanexus/out/output_indices/output_indices
 
 dx-upload-all-outputs

--- a/src/script.sh
+++ b/src/script.sh
@@ -8,10 +8,12 @@ dx-download-all-inputs # download inputs from json
 mkdir /home/dnanexus/genomeDir
 mkdir /home/dnanexus/reference_genome
 mkdir /home/dnanexus/output_indices
-mkdir -p /home/dnanexus/out/output_indices/output_indices
+mkdir /home/dnanexus/gtf
+mkdir -p /home/dnanexus/out/output_indices/
 
 tar xvzf /home/dnanexus/in/sentieon_tar/sentieon-genomics-*.tar.gz -C /usr/local # unpack tar
 tar xvzf /home/dnanexus/in/reference_genome/*tar.gz -C /home/dnanexus/reference_genome
+gunzip /home/dnanexus/in/gtf_file/*.gz
 
 source /home/dnanexus/license_setup.sh # run license setup script
 
@@ -21,12 +23,16 @@ SENTIEON_BIN_DIR=$(echo $SENTIEON_INSTALL_DIR/bin)
 
 export PATH="$SENTIEON_BIN_DIR:$PATH"
 
+# NUMBER_THREADS input to STAR needs the number of cores on the server node
+# This can be extracted from the DNAnexus instance type
+INSTANCE=$(dx describe --json $DX_JOB_ID | jq -r '.instanceType')  # Extract instance type
+
 ## Generate genome indices
 # Define input variables for STAR command
-NUMBER_THREADS=32
+NUMBER_THREADS=${INSTANCE##*_x}
 export REFERENCE=/home/dnanexus/reference_genome/*.fa  # Reference genome, standard GRCh38
 GTF=/home/dnanexus/in/gtf_file/*gtf  # Input .gtf annotation file
-READ_LENGTH_MINUS_1=100
+READ_LENGTH_MINUS_1=99
 OUTPUT_DIR=/home/dnanexus/output_indices
 
 # Run STAR command to generate genome indices

--- a/src/script.sh
+++ b/src/script.sh
@@ -56,8 +56,8 @@ mkdir $output_dir
 ## Generate genome indices
 # Define input variables for STAR command
 number_threads=${instance##*_x}
-export REFERENCE=/home/dnanexus/reference_genome_fasta_and_index/*.fa  # Reference genome, standard GRCh38
-gtf=/home/dnanexus/in/annotated_transcripts_gtf/*gtf  # Input .gtf annotation file
+export REFERENCE=/home/dnanexus/reference_genome_fasta_and_index/*.fa  # Reference genome
+gtf=/home/dnanexus/in/annotated_transcripts_gtf/*gtf  # Annotated transcipts GTF
 let read_length_minus_one=${read_length}-1
 
 # Run STAR command to generate genome indices


### PR DESCRIPTION
### Summary
This app uses a .gtf file of transcripts and the Sentieon STAR tool to generate genome indices, which will annotate a b38 reference genome.

What inputs are required for this app to run?
* `--sentieon_tar`: (file) Tarballed Sentieon package.
Currently defaults to use Sentieon 202112.05
* `--reference_genome_fasta_and_index`:(file) Tarballed GRCh38 reference genome FASTA + index.
Current defaults to use GRCh38.no_alt_analysis_set_chr_mask21.fasta-index.tar.gz in 001_Reference
* `--annotated_transcripts_gtf`: (file) File providing gene transcript information.
Currently defaults to the GENCODE gtf v41 (gencode.v41.annotation.gtf.gz)
* `--read_length_minus_one`: (int) The read length of data with which the genome indices will be used.
Standard for Illumina instruments is 100; so the default for read length minus one is 99.

The output is a tarred and gzipped file of genome indices for the reference genome. The output file name is in the format `ref_{reference_genome_filename}-gtf_{gtf_filename}-readlength{read_length_number}`

Example DNAnexus job: [Job ID: job-GGfvVjQ42QQVZkGp50GY17kv](https://platform.dnanexus.com/projects/GFfV0qQ42QQVf6VX12zxxvx3/monitor/job/GGfvVjQ42QQVZkGp50GY17kv)
![Screenshot from 2022-09-23 16-53-21](https://user-images.githubusercontent.com/71272357/195121976-5062a27b-39d1-476b-9169-12634ad03b04.png)

DNAnexus job after changes: [job-GJ2g26842QQb7zV99ZYVFv0P](https://platform.dnanexus.com/projects/GFfV0qQ42QQVf6VX12zxxvx3/monitor/job/GJ2g26842QQb7zV99ZYVFv0P)
![Screenshot from 2022-10-11 15-35-58](https://user-images.githubusercontent.com/71272357/195121463-bbf02c5b-9f2f-4b49-8cf3-eb52bec20304.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_star_genome_indices/1)
<!-- Reviewable:end -->
